### PR TITLE
Refactored model to support bookops_marc

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,12 +20,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version}}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r dev-requirements.txt
+      - name: Install Poetry with pipx
+        run: pipx install poetry
+      - name: Install dependencies with poetry
+        run: poetry install --no-root --without docs
       - name: Run tests
-        run: pytest -m "not livetest" --cov=overload_web/
+        run: poetry run pytest -m "not livetest" --cov=overload_web/
       - name: Send report to Coveralls
         uses: AndreMiras/coveralls-python-action@develop
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Poetry with pipx
         run: pipx install poetry
       - name: Install dependencies with poetry
-        run: poetry install --no-root --without docs
+        run: poetry install --no-root
       - name: Run tests
         run: poetry run pytest -m "not livetest" --cov=overload_web/
       - name: Send report to Coveralls

--- a/overload_web/adapters/marc_adapters.py
+++ b/overload_web/adapters/marc_adapters.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from bookops_marc import Bib
+from bookops_marc.models import Field
+from bookops_marc.models import Order as BookopsMarcOrder
+
+
+class OverloadOrder(BookopsMarcOrder):
+    def __init__(self, field: Field, following_field: Optional[Field] = None) -> None:
+        super().__init__(field, following_field)
+
+    def _get_subfield_from_following_field(self, code: str) -> Optional[str]:
+        if self._following_field and self._following_field.tag == "961":
+            subfield = self._following_field.get(code, None)
+            return subfield
+        else:
+            return None
+
+    @property
+    def audience(self) -> Optional[str]:
+        return self._field.get("f", None)
+
+    @property
+    def blanket_po(self) -> Optional[str]:
+        return self._get_subfield_from_following_field("m")
+
+    @property
+    def country(self) -> Optional[str]:
+        return self._field.get("x", None)
+
+    @property
+    def fund(self) -> Optional[str]:
+        return self._field.get("u", None)
+
+    @property
+    def internal_note(self) -> Optional[str]:
+        return self._get_subfield_from_following_field("d")
+
+    @property
+    def order_type(self) -> Optional[str]:
+        return self._field.get("i", None)
+
+    @property
+    def price(self) -> Optional[str]:
+        return self._field.get("s", None)
+
+    @property
+    def selector(self) -> Optional[str]:
+        return self._field.get("c", None)
+
+    @property
+    def source(self) -> Optional[str]:
+        return self._field.get("e", None)
+
+    @property
+    def status(self) -> Optional[str]:
+        return self._field.get("m", None)
+
+    @property
+    def vendor_code(self) -> Optional[str]:
+        return self._field.get("v", None)
+
+    @property
+    def var_field_isbn(self) -> Optional[str]:
+        return self._get_subfield_from_following_field("l")
+
+    @property
+    def selector_note(self) -> Optional[str]:
+        return self._get_subfield_from_following_field("f")
+
+    @property
+    def vendor_title_no(self) -> Optional[str]:
+        return self._get_subfield_from_following_field("i")
+
+    @staticmethod
+    def orders_from_bib(record: Bib) -> List[OverloadOrder]:
+        orders: List[OverloadOrder] = []
+        for field in record:
+            if field.tag == "960":
+                try:
+                    following_field = record.fields[record.pos]
+                except IndexError:
+                    following_field = None
+                orders.append(OverloadOrder(field, following_field))
+        return orders

--- a/overload_web/adapters/sierra_adapters.py
+++ b/overload_web/adapters/sierra_adapters.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 import logging
 import os
+from abc import ABC, abstractmethod
 from typing import List
 
-from bookops_nypl_platform import PlatformSession, PlatformToken
-from bookops_bpl_solr import SolrSession
 import requests
+from bookops_bpl_solr import SolrSession
+from bookops_nypl_platform import PlatformSession, PlatformToken
 
-from overload_web.domain import model
+from overload_web.domain import refactored_model
+
 from .. import __title__, __version__
 
 logger = logging.getLogger(__name__)
@@ -21,10 +22,12 @@ class SierraService:
     def __init__(self, session: AbstractSierraSession):
         self.session = session
 
-    def get_all_bib_ids(self, order: model.Order, match_keys: List[str]) -> List[str]:
+    def get_all_bib_ids(
+        self, order_bib: refactored_model.OrderBib, match_keys: List[str]
+    ) -> List[str]:
         bibs = []
         for key in match_keys:
-            bibs = self.session.get_bibs_by_id(key, getattr(order, f"{key}"))
+            bibs = self.session.get_bibs_by_id(key, getattr(order_bib, f"{key}"))
             if not bibs:
                 continue
         return bibs

--- a/overload_web/domain/refactored_model.py
+++ b/overload_web/domain/refactored_model.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import datetime
+from dataclasses import asdict, dataclass
+from typing import List, Optional, Union
+
+
+def apply_template(bib: OrderBib, template: Template) -> OrderBib:
+    for order in bib.orders:
+        template_dict = asdict(template)
+        for k, v in template_dict.items():
+            if v and "matchpoint" not in k:
+                setattr(order, k, v)
+    return bib
+
+
+@dataclass
+class OrderBib:
+    library: str
+    orders: List[Order]
+    bib_id: Optional[str] = None
+    isbn: Optional[str] = None
+    oclc_number: Optional[Union[str, List[str]]] = None
+    upc: Optional[str] = None
+
+    def attach(self, bib_ids: List[str]) -> None:
+        if bib_ids:
+            self.bib_id = bib_ids[0]
+            self.all_bib_ids = bib_ids
+        else:
+            self.all_bib_ids = []
+
+
+@dataclass
+class Order:
+    audience: Optional[str]
+    blanket_po: Optional[str]
+    copies: Optional[Union[str, int]]
+    country: Optional[str]
+    create_date: Optional[Union[datetime.datetime, datetime.date, str]]
+    format: Optional[str]
+    fund: Optional[str]
+    internal_note: Optional[str]
+    lang: Optional[str]
+    locations: List[str]
+    order_type: Optional[str]
+    price: Optional[Union[str, int]]
+    selector: Optional[str]
+    selector_note: Optional[str]
+    source: Optional[str]
+    status: Optional[str]
+    var_field_isbn: Optional[str]
+    vendor_code: Optional[str]
+    vendor_notes: Optional[str]
+    vendor_title_no: Optional[str]
+
+
+@dataclass
+class Template:
+    audience: Optional[str] = None
+    blanket_po: Optional[str] = None
+    copies: Optional[Union[str, int]] = None
+    country: Optional[str] = None
+    create_date: Optional[Union[datetime.datetime, datetime.date, str]] = None
+    format: Optional[str] = None
+    fund: Optional[str] = None
+    internal_note: Optional[str] = None
+    lang: Optional[str] = None
+    order_type: Optional[str] = None
+    price: Optional[Union[str, int]] = None
+    selector: Optional[str] = None
+    selector_note: Optional[str] = None
+    source: Optional[str] = None
+    status: Optional[str] = None
+    var_field_isbn: Optional[str] = None
+    vendor_code: Optional[str] = None
+    vendor_notes: Optional[str] = None
+    vendor_title_no: Optional[str] = None
+
+    primary_matchpoint: Optional[str] = None
+    secondary_matchpoint: Optional[str] = None
+    tertiary_matchpoint: Optional[str] = None
+
+    @property
+    def matchpoints(self) -> List[str]:
+        return [
+            i
+            for i in [
+                self.primary_matchpoint,
+                self.secondary_matchpoint,
+                self.tertiary_matchpoint,
+            ]
+            if i
+        ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,6 +54,25 @@ reference = "HEAD"
 resolved_reference = "0dfd0bb91294df768ebfab4631188b799b7c1151"
 
 [[package]]
+name = "bookops-marc"
+version = "0.12.0"
+description = "A sweetened `pymarc.Record` module for extraction of data from local Sierra records."
+optional = false
+python-versions = "^3.8"
+groups = ["main"]
+files = []
+develop = false
+
+[package.dependencies]
+pymarc = "^5.2.3"
+
+[package.source]
+type = "git"
+url = "https://github.com/BookOps-CAT/bookops-marc.git"
+reference = "releases/v0.12.0"
+resolved_reference = "4bd5da6ac6368ae25f3a422e1560bd2bb02de4ac"
+
+[[package]]
 name = "bookops-nypl-platform"
 version = "0.5.0"
 description = "BookOps Python wrapper around NYPL Platform API"
@@ -848,14 +867,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymarc"
-version = "5.2.2"
+version = "5.2.3"
 description = "Read, write and modify MARC bibliographic data"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pymarc-5.2.2-py3-none-any.whl", hash = "sha256:d654ee1faae5d80845b7a44b27deb6ea9b5377994d16aeba5d3e19e7856d7d43"},
-    {file = "pymarc-5.2.2.tar.gz", hash = "sha256:0913b4167a4337190598914c3642c5ae4f0f64a26bc4316f380cc54f65d8a741"},
+    {file = "pymarc-5.2.3-py3-none-any.whl", hash = "sha256:9e0b2fff0f97764889fe2af08a93d137e0a46630c006c6330bebf0bdcd52201a"},
+    {file = "pymarc-5.2.3.tar.gz", hash = "sha256:02a151d89c3b36f92bbc92c2e972bcfe91b91fc93529d8862e5f7c292a15c9f0"},
 ]
 
 [[package]]
@@ -1426,4 +1445,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "553afadf2bdb3b37a84cd6cc846f36eac5c2c7d0efde2dc5129206dad99aac0e"
+content-hash = "1267f3193e35589bc85ac7cbbc9dbcc1010aaa9219ab84f1804418ac881eec8a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ bookops-worldcat = "^1.1.0"
 bookops-nypl-platform = {git = "https://github.com/BookOps-CAT/bookops-nypl-platform.git"}
 bookops-bpl-solr = {git = "https://github.com/BookOps-CAT/bookops-bpl-solr.git"}
 fastapi = {extras = ["standard"], version = "^0.115.6"}
+bookops-marc = {git = "https://github.com/BookOps-CAT/bookops-marc.git", rev = "releases/v0.12.0"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from pymarc import Field, Indicators, Subfield
 
 from overload_web.adapters.sierra_adapters import (
     AbstractSierraSession,
@@ -113,4 +114,54 @@ def stub_template():
         primary_matchpoint="isbn",
         secondary_matchpoint=None,
         tertiary_matchpoint=None,
+    )
+
+
+@pytest.fixture
+def stub_960():
+    return Field(
+        tag="960",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(code="a", value="l"),
+            Subfield(code="b", value="-"),
+            Subfield(code="c", value="j"),
+            Subfield(code="d", value="c"),
+            Subfield(code="e", value="d"),
+            Subfield(code="f", value="a"),
+            Subfield(code="g", value="b"),
+            Subfield(code="h", value="-"),
+            Subfield(code="i", value="l"),
+            Subfield(code="j", value="-"),
+            Subfield(code="m", value="o"),
+            Subfield(code="n", value="-"),
+            Subfield(code="o", value="13"),
+            Subfield(code="p", value="  -  -  "),
+            Subfield(code="q", value="01-01-25"),
+            Subfield(code="r", value="  -  -  "),
+            Subfield(code="s", value="{{dollar}}13.20"),
+            Subfield(code="t", value="agj0y"),
+            Subfield(code="u", value="lease"),
+            Subfield(code="v", value="btlea"),
+            Subfield(code="w", value="eng"),
+            Subfield(code="x", value="xxu"),
+            Subfield(code="y", value="1"),
+            Subfield(code="z", value=".o10000010"),
+        ],
+    )
+
+
+@pytest.fixture
+def stub_961():
+    return Field(
+        tag="961",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(code="d", value="foo"),
+            Subfield(code="f", value="bar"),
+            Subfield(code="h", value="baz"),
+            Subfield(code="i", value="foo"),
+            Subfield(code="l", value="bar"),
+            Subfield(code="m", value="baz"),
+        ],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 import pytest
 
-from overload_web.domain.model import Order, OrderTemplate
 from overload_web.adapters.sierra_adapters import (
-    SierraService,
     AbstractSierraSession,
+    SierraService,
 )
+from overload_web.domain.model import Order, OrderTemplate
 
 
 class MockSierraAdapter(AbstractSierraSession):
@@ -92,25 +92,25 @@ def stub_order(library):
 @pytest.fixture
 def stub_template():
     return OrderTemplate(
-        "2024-01-01",
-        "$20.00",
-        "10001adbk",
-        "5",
-        "spa",
-        "xxu",
-        "0049",
-        "a",
-        "b",
-        "a",
-        "d",
-        "p",
-        "o",
-        "foo",
-        None,
-        "bar",
-        None,
-        None,
-        "isbn",
-        None,
-        None,
+        create_date="2024-01-01",
+        price="$20.00",
+        fund="10001adbk",
+        copies="5",
+        lang="spa",
+        country="xxu",
+        vendor_code="0049",
+        format="a",
+        selector="b",
+        audience="a",
+        source="d",
+        order_type="p",
+        status="o",
+        internal_note="foo",
+        var_field_isbn=None,
+        vendor_notes="bar",
+        vendor_title_no=None,
+        blanket_po=None,
+        primary_matchpoint="isbn",
+        secondary_matchpoint=None,
+        tertiary_matchpoint=None,
     )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,50 @@
+import datetime
+
+from overload_web.adapters import marc_adapters
+
+
+class TestOverloadOrder:
+    def test_OverloadOrder(self, stub_960, stub_961):
+        order = marc_adapters.OverloadOrder(stub_960, stub_961)
+        assert order.audience == "a"
+        assert order.blanket_po == "baz"
+        assert order.copies == 13
+        assert order.country == "xxu"
+        assert order.created == datetime.date(2025, 1, 1)
+        assert order.form == "b"
+        assert order.fund == "lease"
+        assert order.internal_note == "foo"
+        assert order.lang == "eng"
+        assert order.locs == ["agj0y"]
+        assert order.order_type == "l"
+        assert order.price == "{{dollar}}13.20"
+        assert order.selector == "j"
+        assert order.source == "d"
+        assert order.status == "o"
+        assert order.var_field_isbn == "bar"
+        assert order.vendor_code == "btlea"
+        assert order.venNotes == "baz"
+        assert order.vendor_title_no == "foo"
+
+    def test_OverloadOrder_no_var_fields(self, stub_960):
+        order = marc_adapters.OverloadOrder(stub_960)
+        assert order.audience == "a"
+        assert order.blanket_po is None
+        assert order.copies == 13
+        assert order.country == "xxu"
+        assert order.created == datetime.date(2025, 1, 1)
+        assert order.form == "b"
+        assert order.fund == "lease"
+        assert order.internal_note is None
+        assert order.lang == "eng"
+        assert order.locs == ["agj0y"]
+        assert order.order_type == "l"
+        assert order.price == "{{dollar}}13.20"
+        assert order.selector == "j"
+        assert order.selector_note is None
+        assert order.source == "d"
+        assert order.status == "o"
+        assert order.var_field_isbn is None
+        assert order.vendor_code == "btlea"
+        assert order.venNotes is None
+        assert order.vendor_title_no is None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,108 +1,200 @@
 from datetime import datetime
+
 import pytest
-from overload_web.domain.model import (
-    OrderBib,
-    Order,
-    OrderTemplate,
-    apply_template,
-)
+
+from overload_web.domain import model, refactored_model
 
 
-@pytest.mark.parametrize("library", ["nypl", "bpl"])
-def test_Order(library):
-    order = Order(
-        isbn="9781234567890",
-        library=library,
-        create_date=datetime(2024, 1, 1),
-        locations=["(4)fwa0f", "(2)bca0f", "gka0f"],
-        shelves=["0f", "0f", "0f"],
-        price="$5.00",
-        fund="25240adbk",
-        copies="7",
-        lang="eng",
-        country="xxu",
-        vendor_code="0049",
-        format="a",
-        selector="b",
-        audience=["a", "a", "a"],
-        source="d",
-        order_type="p",
-        status="o",
-        internal_note=None,
-        var_field_isbn=None,
-        vendor_notes=None,
-        vendor_title_no=None,
-        blanket_po=None,
-    )
-    assert order.isbn == "9781234567890"
-    assert order.oclc_number is None
-    assert order.upc is None
-    assert order.bib_id is None
+class TestDomainModel:
+    @pytest.mark.parametrize("library", ["nypl", "bpl"])
+    def test_Order(self, library):
+        order = model.Order(
+            isbn="9781234567890",
+            library=library,
+            create_date=datetime(2024, 1, 1),
+            locations=["(4)fwa0f", "(2)bca0f", "gka0f"],
+            shelves=["0f", "0f", "0f"],
+            price="$5.00",
+            fund="25240adbk",
+            copies="7",
+            lang="eng",
+            country="xxu",
+            vendor_code="0049",
+            format="a",
+            selector="b",
+            audience=["a", "a", "a"],
+            source="d",
+            order_type="p",
+            status="o",
+            internal_note=None,
+            var_field_isbn=None,
+            vendor_notes=None,
+            vendor_title_no=None,
+            blanket_po=None,
+        )
+        assert order.isbn == "9781234567890"
+        assert order.oclc_number is None
+        assert order.upc is None
+        assert order.bib_id is None
+
+    def test_OrderTemplate(self):
+        template = model.OrderTemplate(
+            datetime(2024, 1, 1),
+            "$5.00",
+            "25240adbk",
+            "7",
+            "eng",
+            "xxu",
+            "0049",
+            "a",
+            "b",
+            "a",
+            "d",
+            "p",
+            "o",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        assert template.create_date == datetime(2024, 1, 1)
+        assert template.price == "$5.00"
+        assert template.fund == "25240adbk"
+        assert template.copies == "7"
+        assert template.lang == "eng"
+        assert template.country == "xxu"
+        assert template.vendor_code == "0049"
+        assert template.format == "a"
+        assert template.selector == "b"
+        assert template.audience == "a"
+        assert template.source == "d"
+        assert template.order_type == "p"
+        assert template.status == "o"
+        assert template.internal_note is None
+        assert template.var_field_isbn is None
+        assert template.vendor_notes is None
+        assert template.vendor_title_no is None
+        assert template.blanket_po is None
+        assert template.primary_matchpoint is None
+        assert template.secondary_matchpoint is None
+        assert template.tertiary_matchpoint is None
+        assert template.matchpoints == []
+
+    @pytest.mark.parametrize("library", ["bpl", "nypl"])
+    def test_OrderBib(self, stub_order):
+        bib = model.OrderBib(order=stub_order)
+        assert stub_order.bib_id is None
+        assert bib.bib_id is None
+
+    @pytest.mark.parametrize("library", ["bpl", "nypl"])
+    def test_OrderBib_bib_id(self, stub_order):
+        order = stub_order
+        order.bib_id = "b123456789"
+        bib = model.OrderBib(order=order)
+        assert bib.bib_id == "b123456789"
+
+    @pytest.mark.parametrize("library", ["bpl", "nypl"])
+    def test_model_apply_template(self, stub_template, stub_order):
+        bib = model.OrderBib(order=stub_order)
+        assert bib.fund == "25240adbk"
+        updated_bib = model.apply_template(bib, stub_template)
+        assert updated_bib.fund == "10001adbk"
 
 
-def test_OrderTemplate():
-    template = OrderTemplate(
-        datetime(2024, 1, 1),
-        "$5.00",
-        "25240adbk",
-        "7",
-        "eng",
-        "xxu",
-        "0049",
-        "a",
-        "b",
-        "a",
-        "d",
-        "p",
-        "o",
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
-    assert template.create_date == datetime(2024, 1, 1)
-    assert template.price == "$5.00"
-    assert template.fund == "25240adbk"
-    assert template.copies == "7"
-    assert template.lang == "eng"
-    assert template.country == "xxu"
-    assert template.vendor_code == "0049"
-    assert template.format == "a"
-    assert template.selector == "b"
-    assert template.audience == "a"
-    assert template.source == "d"
-    assert template.order_type == "p"
-    assert template.status == "o"
-    assert template.internal_note is None
-    assert template.var_field_isbn is None
-    assert template.vendor_notes is None
-    assert template.vendor_title_no is None
-    assert template.blanket_po is None
-    assert template.primary_matchpoint is None
-    assert template.secondary_matchpoint is None
-    assert template.tertiary_matchpoint is None
-    assert template.matchpoints == []
+class TestRefactoredModel:
+    def test_Order(self):
+        order = refactored_model.Order(
+            create_date=datetime(2024, 1, 1),
+            locations=["(4)fwa0f", "(2)bca0f", "gka0f"],
+            price="$5.00",
+            fund="25240adbk",
+            copies="7",
+            lang="eng",
+            country="xxu",
+            vendor_code="0049",
+            format="a",
+            selector="b",
+            selector_note=None,
+            audience="a",
+            source="d",
+            order_type="p",
+            status="o",
+            internal_note=None,
+            var_field_isbn=None,
+            vendor_notes=None,
+            vendor_title_no=None,
+            blanket_po=None,
+        )
+        assert order.price == "$5.00"
+        assert order.format == "a"
+        assert order.blanket_po is None
 
+    def test_Template(self):
+        template = refactored_model.Template(
+            audience="a",
+            blanket_po=None,
+            copies="7",
+            country="xxu",
+            create_date=datetime(2024, 1, 1),
+            format="a",
+            fund="25240adbk",
+            internal_note=None,
+            lang="eng",
+            order_type="p",
+            price="$5.00",
+            selector="b",
+            selector_note=None,
+            source="d",
+            status="o",
+            var_field_isbn=None,
+            vendor_code="0049",
+            vendor_notes=None,
+            vendor_title_no=None,
+            primary_matchpoint=None,
+            secondary_matchpoint=None,
+            tertiary_matchpoint=None,
+        )
+        assert template.create_date == datetime(2024, 1, 1)
+        assert template.price == "$5.00"
+        assert template.fund == "25240adbk"
+        assert template.copies == "7"
+        assert template.lang == "eng"
+        assert template.country == "xxu"
+        assert template.vendor_code == "0049"
+        assert template.format == "a"
+        assert template.selector == "b"
+        assert template.selector_note is None
+        assert template.audience == "a"
+        assert template.source == "d"
+        assert template.order_type == "p"
+        assert template.status == "o"
+        assert template.internal_note is None
+        assert template.var_field_isbn is None
+        assert template.vendor_notes is None
+        assert template.vendor_title_no is None
+        assert template.blanket_po is None
+        assert template.primary_matchpoint is None
+        assert template.secondary_matchpoint is None
+        assert template.tertiary_matchpoint is None
+        assert template.matchpoints == []
 
-@pytest.mark.parametrize("library", ["bpl", "nypl"])
-def test_OrderBib(stub_order):
-    bib = OrderBib(order=stub_order)
-    assert stub_order.bib_id is None
-    assert bib.bib_id is None
+    @pytest.mark.parametrize("library", ["bpl", "nypl"])
+    def test_OrderBib(self, library, stub_order):
+        bib = refactored_model.OrderBib(library=library, orders=[stub_order])
+        assert bib.bib_id is None
 
+    @pytest.mark.parametrize("library", ["bpl", "nypl"])
+    def test_OrderBib_bib_id(self, library, stub_order):
+        order = stub_order
+        bib = refactored_model.OrderBib(
+            library=library, orders=[order], bib_id="b123456789"
+        )
+        assert bib.bib_id == "b123456789"
 
-@pytest.mark.parametrize("library", ["bpl", "nypl"])
-def test_OrderBib_bib_id(stub_order):
-    order = stub_order
-    order.bib_id = "b123456789"
-    bib = OrderBib(order=order)
-    assert bib.bib_id == "b123456789"
-
-
-@pytest.mark.parametrize("library", ["bpl", "nypl"])
-def test_model_apply_template(stub_template, stub_order):
-    bib = OrderBib(order=stub_order)
-    assert bib.fund == "25240adbk"
-    updated_bib = apply_template(bib, stub_template)
-    assert updated_bib.fund == "10001adbk"
+    @pytest.mark.parametrize("library", ["bpl", "nypl"])
+    def test_model_apply_template(self, library, stub_template, stub_order):
+        bib = refactored_model.OrderBib(library=library, orders=[stub_order])
+        assert bib.orders[0].fund == "25240adbk"
+        updated_bib = refactored_model.apply_template(bib, stub_template)
+        assert updated_bib.orders[0].fund == "10001adbk"


### PR DESCRIPTION
Added:
 - `OrderloadOrder` class to support integration of `bookops-marc` into package
 - `bookops-marc` is now a dependency
 
Changed:
 - updated github actions to use poetry to install dependencies rather than pip
 - refactored domain model:
   - `OrderTemplate` is now `Template`. `Template` contains the same attributes as `OrderTemplate` but the parameters were reorganized within the file.
   - `Order` dataclass no longer contains `bib_id`, `isbn`, `oclc_number`, `upc`, or `library`
   - `OrderBib` now contains `bib_id`, `isbn`, `oclc_number`, `upc`, `library`, and a list of `Order` objects
 - refactored model is in a separate file to reduce the changes necessary in this refactor