### PR TITLE
Updated `Template` and added `Matchpoints` dataclass

### DIFF
--- a/overload_web/infrastructure/orm.py
+++ b/overload_web/infrastructure/orm.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Date, Integer, MetaData, String, Table
-from sqlalchemy.orm import registry
+from sqlalchemy.orm import composite, registry
 
 from overload_web.domain import model
 
@@ -31,11 +31,22 @@ templates = Table(
     Column("vendor_code", String),
     Column("vendor_notes", String),
     Column("vendor_title_no", String),
-    Column("primary_matchpoint", String, nullable=False),
+    Column("primary_matchpoint", String),
     Column("secondary_matchpoint", String),
     Column("tertiary_matchpoint", String),
 )
 
 
 def start_mappers() -> None:
-    mapper_registry.map_imperatively(model.Template, templates)
+    mapper_registry.map_imperatively(
+        model.Template,
+        templates,
+        properties={
+            "matchpoints": composite(
+                model.Matchpoints,
+                templates.c.primary_matchpoint,
+                templates.c.secondary_matchpoint,
+                templates.c.tertiary_matchpoint,
+            )
+        },
+    )

--- a/overload_web/presentation/api/schemas.py
+++ b/overload_web/presentation/api/schemas.py
@@ -17,15 +17,20 @@ class BibModel(BaseModel, model.DomainBib):
     model_config = ConfigDict(from_attributes=True)
 
 
+class MatchpointsModel(BaseModel, model.Matchpoints):
+    model_config = ConfigDict(from_attributes=True)
+
+
 class TemplateModel(BaseModel, model.Template):
     model_config = ConfigDict(from_attributes=True)
 
     @classmethod
     def from_form_data(
         cls,
-        agent: Annotated[Optional[Union[str]], Form()] = None,
-        name: Annotated[Optional[Union[str]], Form()] = None,
-        id: Annotated[Optional[Union[str]], Form()] = None,
+        agent: Annotated[Optional[str], Form()] = None,
+        name: Annotated[Optional[str], Form()] = None,
+        id: Annotated[Optional[str], Form()] = None,
+        audience: Annotated[Optional[str], Form()] = None,
         create_date: Annotated[Optional[Union[datetime.datetime, str]], Form()] = None,
         price: Annotated[Optional[Union[str, int]], Form()] = None,
         fund: Annotated[Optional[str], Form()] = None,
@@ -49,6 +54,7 @@ class TemplateModel(BaseModel, model.Template):
         tertiary_matchpoint: Annotated[Optional[str], Form()] = None,
     ) -> TemplateModel:
         return TemplateModel(
+            audience=audience,
             create_date=create_date,
             fund=fund,
             vendor_code=vendor_code,
@@ -70,7 +76,9 @@ class TemplateModel(BaseModel, model.Template):
             name=name,
             id=id,
             agent=agent,
-            primary_matchpoint=primary_matchpoint,
-            secondary_matchpoint=secondary_matchpoint,
-            tertiary_matchpoint=tertiary_matchpoint,
+            matchpoints=MatchpointsModel(
+                primary=primary_matchpoint,
+                secondary=secondary_matchpoint,
+                tertiary=tertiary_matchpoint,
+            ),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,11 @@ def mock_sierra_response(monkeypatch):
 
 
 @pytest.fixture
+def bib_data(order_data, library) -> dict:
+    return {"library": library, "orders": [order_data]}
+
+
+@pytest.fixture
 def order_data() -> dict:
     return {
         "audience": "a",
@@ -103,15 +108,12 @@ def template_data() -> dict:
         "vendor_code": "0049",
         "vendor_notes": "bar",
         "vendor_title_no": None,
-        "primary_matchpoint": "isbn",
-        "secondary_matchpoint": None,
-        "tertiary_matchpoint": None,
+        "matchpoints": {
+            "primary": "isbn",
+            "secondary": None,
+            "tertiary": None,
+        },
     }
-
-
-@pytest.fixture
-def bib_data(order_data, library) -> dict:
-    return {"library": library, "orders": [order_data]}
 
 
 @pytest.fixture
@@ -192,6 +194,10 @@ def stub_binary_marc(stub_bib) -> io.BytesIO:
 
 @pytest.fixture
 def stub_pvf_form_data(template_data, library, destination) -> dict:
-    template_data["library"] = library
-    template_data["destination"] = destination
-    return template_data
+    pvf_form_data = {k: v for k, v in template_data.items() if k != "matchpoints"}
+    pvf_form_data["primary_matchpoint"] = template_data["matchpoints"]["primary"]
+    pvf_form_data["secondary_matchpoint"] = template_data["matchpoints"]["secondary"]
+    pvf_form_data["tertiary_matchpoint"] = template_data["matchpoints"]["tertiary"]
+    pvf_form_data["library"] = library
+    pvf_form_data["destination"] = destination
+    return pvf_form_data

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import clear_mappers, sessionmaker
@@ -57,41 +55,19 @@ def test_SqlAlchemyRepository(session):
         (4, "Qux Template", "user3"),
     ],
 )
-def test_SqlAlchemyRepository_get_save(id, name, agent, session, template_data):
+def test_SqlAlchemyRepository_get_save(id, name, agent, session):
     repo = repository.SqlAlchemyRepository(session=session)
-    template_data["id"], template_data["name"], template_data["agent"] = id, name, agent
-    template_data["create_date"] = datetime.date(2024, 1, 1)
-    template = model.Template(**template_data)
-    assert isinstance(template, model.Template)
-    repo.save(template)
-    saved_template = repo.get(id=id)
-    assert saved_template == model.Template(
+    template = model.Template(
         id=id,
         name=name,
         agent=agent,
-        audience="a",
-        blanket_po=None,
-        copies="5",
         country="xxu",
-        create_date=datetime.date(2024, 1, 1),
-        format="a",
-        fund="10001adbk",
-        internal_note="foo",
-        lang="spa",
-        order_type="p",
-        price="$20.00",
-        selector="b",
-        selector_note=None,
-        source="d",
-        status="o",
-        var_field_isbn=None,
-        vendor_code="0049",
-        vendor_notes="bar",
-        vendor_title_no=None,
-        primary_matchpoint="isbn",
-        secondary_matchpoint=None,
-        tertiary_matchpoint=None,
+        matchpoints=model.Matchpoints("isbn"),
     )
+    assert isinstance(template, model.Template)
+    repo.save(template)
+    saved_template = repo.get(id=id)
+    assert saved_template == template
 
 
 def test_mappers(session):
@@ -110,21 +86,21 @@ def test_mappers(session):
             name="Foo Template",
             agent="user1",
             vendor_code="FOO",
-            primary_matchpoint="isbn",
+            matchpoints=model.Matchpoints(primary="isbn"),
         ),
         model.Template(
             id=2,
             name="Bar Template",
             agent="user2",
             vendor_code="BAR",
-            primary_matchpoint="upc",
+            matchpoints=model.Matchpoints(primary="upc"),
         ),
         model.Template(
             id=3,
             name="Baz Template",
             agent="user1",
             vendor_code="BAZ",
-            primary_matchpoint="isbn",
+            matchpoints=model.Matchpoints(primary="isbn"),
         ),
     ]
     assert session.query(model.Template).all() == expected

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,7 +7,7 @@ from overload_web.infrastructure import sierra_adapters
 def fake_sierra_service():
     class FakeSierraService(sierra_adapters.AbstractService):
         def _get_bibs_by_id(self, value, key):
-            return [{"id": "123456789"}]
+            return [{"id": "123456789", key: value}]
 
     return FakeSierraService()
 
@@ -26,9 +26,47 @@ class MockUnitOfWork(unit_of_work.AbstractUnitOfWork):
         pass
 
 
+class TestAbstractUnitOfWork:
+    def test_commit(self):
+        unit_of_work.AbstractUnitOfWork.__abstractmethods__ = set()
+        uow = unit_of_work.AbstractUnitOfWork()
+        with pytest.raises(NotImplementedError):
+            uow.commit()
+
+    def test_rollback(self):
+        unit_of_work.AbstractUnitOfWork.__abstractmethods__ = set()
+        uow = unit_of_work.AbstractUnitOfWork()
+        with pytest.raises(NotImplementedError):
+            uow.rollback()
+
+
 @pytest.mark.usefixtures("mock_sierra_response")
 @pytest.mark.parametrize("library", ["nypl", "bpl"])
 class TestApplicationServices:
+    def test_get_bibs_by_key(self, bib_data, library):
+        bib_data["isbn"] = "9781234567890"
+        bibs = services.get_bibs_by_key(
+            uow=MockUnitOfWork(), bib=bib_data, matchpoints=["isbn"]
+        )
+        assert bibs == [
+            {
+                "library": library,
+                "orders": [],
+                "bib_id": "123456789",
+                "isbn": "9781234567890",
+                "oclc_number": None,
+                "upc": None,
+            }
+        ]
+
+    def test_get_bibs_by_key_None(self, bib_data, library):
+        bibs = services.get_bibs_by_key(
+            uow=MockUnitOfWork(),
+            bib=bib_data,
+            matchpoints=["isbn"],
+        )
+        assert bibs == []
+
     def test_match_bib(self, bib_data, library):
         bib_data["isbn"] = "9781234567890"
         matched_bib = services.match_bib(


### PR DESCRIPTION
Added
 - `Matchpoints` dataclass to use when matching bib records without applying a template
 - `DomainBib` now has `apply_template` method for `orders` attribute

Changed
 - `Template` dataclass now has `matchpoints` attribute which is a `Matchpoints` object
 - updated orm mapping to account for template data coming from two different dataclasses