### PR TITLE
Protocols

### DIFF
--- a/overload_web/application/services.py
+++ b/overload_web/application/services.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any, BinaryIO, Dict, List, Sequence
 
-from overload_web.application import marc_adapters, unit_of_work
+from overload_web.application import unit_of_work
 from overload_web.domain import model
+from overload_web.infrastructure import marc_adapters
 
 
 def get_bibs_by_key(
@@ -17,19 +18,7 @@ def get_bibs_by_key(
             value = bib.get(key)
             if not value:
                 continue
-            bibs.extend(
-                [
-                    {
-                        "library": bib["library"],
-                        "orders": [],
-                        "bib_id": i["id"],
-                        "isbn": i.get("isbn"),
-                        "oclc_number": i.get("oclc_number"),
-                        "upc": i.get("upc"),
-                    }
-                    for i in uow.bibs.get_bibs_by_id(value=value, key=key)
-                ]
-            )
+            bibs.extend([i for i in uow.bibs.get_bibs_by_id(value=value, key=key)])
         return bibs
 
 
@@ -46,38 +35,13 @@ def match_bib(
             if not value:
                 continue
             sierra_bibs = uow.bibs.get_bibs_by_id(value=value, key=key)
-            bibs.extend(
-                [
-                    {
-                        "library": bib["library"],
-                        "orders": [],
-                        "bib_id": i["id"],
-                        "isbn": i.get("isbn"),
-                        "oclc_number": i.get("oclc_number"),
-                        "upc": i.get("upc"),
-                    }
-                    for i in sierra_bibs
-                ]
-            )
+            for bib in sierra_bibs:
+                bib.update({"library": domain_bib.library, "orders": []})
+            bibs.extend(sierra_bibs)
         domain_bibs = [model.DomainBib(**i) for i in bibs]
         domain_bib.match(bibs=domain_bibs, matchpoints=matchpoints)
         return domain_bib.__dict__
 
 
-def process_marc_file(
-    bib_data: BinaryIO, library: str, uow: unit_of_work.OverloadUnitOfWork
-) -> Sequence[model.DomainBib]:
-    bibs = []
-    reader = marc_adapters.read_marc_file(bib_data, library=library)
-    for bib in reader:
-        orders = [uow.order_factory.to_domain(i) for i in bib.orders]
-        domain_bib = model.DomainBib(
-            library=bib.library,
-            orders=orders,
-            bib_id=bib.sierra_bib_id,
-            isbn=bib.isbn,
-            oclc_number=list(bib.oclc_nos.values()),
-            upc=bib.upc_number,
-        )
-        bibs.append(domain_bib)
-    return bibs
+def process_marc_file(bib_data: BinaryIO, library: str) -> Sequence[model.DomainBib]:
+    return [i for i in marc_adapters.read_marc_file(bib_data, library=library)]

--- a/overload_web/application/unit_of_work.py
+++ b/overload_web/application/unit_of_work.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 from typing import Callable, Protocol, runtime_checkable
 
 from sqlalchemy import create_engine
@@ -11,7 +10,7 @@ from overload_web.infrastructure import repository, sierra_adapters
 
 @runtime_checkable
 class UnitOfWorkProtocol(Protocol):
-    db_bibs: repository.AbstractRepository
+    db_bibs: repository.RepositoryProtocol
     bibs: sierra_adapters.SierraBibFetcher
 
     def __enter__(self) -> UnitOfWorkProtocol:
@@ -20,11 +19,9 @@ class UnitOfWorkProtocol(Protocol):
     def __exit__(self, *args):
         self.rollback()
 
-    @abc.abstractmethod
     def commit(self):
         raise NotImplementedError
 
-    @abc.abstractmethod
     def rollback(self):
         raise NotImplementedError
 

--- a/overload_web/domain/match_service.py
+++ b/overload_web/domain/match_service.py
@@ -1,0 +1,6 @@
+from typing import Any, Dict, List, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BibFetcher(Protocol):
+    def get_bibs_by_id(self, value: str | int, key: str) -> List[Dict[str, Any]]: ...

--- a/overload_web/infrastructure/repository.py
+++ b/overload_web/infrastructure/repository.py
@@ -1,20 +1,16 @@
-import abc
-from typing import Union
+from typing import Protocol, Union, runtime_checkable
 
 from overload_web.domain import model
 
 
-class AbstractRepository(abc.ABC):
-    @abc.abstractmethod
-    def get(self, id: Union[str, int]) -> model.Template:
-        raise NotImplementedError
+@runtime_checkable
+class RepositoryProtocol(Protocol):
+    def get(self, id: Union[str, int]) -> model.Template: ...
 
-    @abc.abstractmethod
-    def save(self, template: model.Template):
-        raise NotImplementedError
+    def save(self, template: model.Template) -> None: ...
 
 
-class SqlAlchemyRepository(AbstractRepository):
+class SqlAlchemyRepository:
     def __init__(self, session):
         self.session = session
 

--- a/overload_web/presentation/api/overload_api.py
+++ b/overload_web/presentation/api/overload_api.py
@@ -23,7 +23,7 @@ def vendor_file_process(
 ) -> Sequence[schemas.BibModel]:
     processed_bibs = []
     uow = unit_of_work.OverloadUnitOfWork(library=library)
-    bibs = services.process_marc_file(bib_data=file.file, library=library, uow=uow)
+    bibs = services.process_marc_file(bib_data=file.file, library=library)
     for bib in bibs:
         for order in bib.orders:
             order.apply_template(template_data=vars(template))

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -20,27 +20,6 @@ def session(in_memory_db):
     clear_mappers()
 
 
-def test_AbstractRepository():
-    repository.AbstractRepository.__abstractmethods__ = set()
-    session = repository.AbstractRepository()
-    assert session.__dict__ == {}
-
-
-def test_AbstractRepository_get():
-    repo = repository.AbstractRepository()
-    with pytest.raises(NotImplementedError) as exc:
-        repo.get(id=1)
-    assert str(exc.value) == ""
-
-
-def test_AbstractRepository_save(template_data):
-    repo = repository.AbstractRepository()
-    template_data["id"], template_data["name"], template_data["agent"] = 1, "Foo", "Bar"
-    with pytest.raises(NotImplementedError) as exc:
-        repo.save(template=template_data)
-    assert str(exc.value) == ""
-
-
 def test_SqlAlchemyRepository(session):
     repo = repository.SqlAlchemyRepository(session=session)
     assert hasattr(repo, "session")

--- a/tests/unit/test_sierra_adapters.py
+++ b/tests/unit/test_sierra_adapters.py
@@ -25,78 +25,6 @@ def live_creds() -> None:
             os.environ[k] = v
 
 
-class TestAbstractObjects:
-    def test_AbstractSierraSession__get_credentials(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_credentials()
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__get_target(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_target()
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__get_bibs_by_bib_id(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_bib_id("12345")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__get_bibs_by_isbn(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_isbn("12345")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__get_bibs_by_issn(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_issn("12345")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__get_bibs_by_oclc_number(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_oclc_number("12345")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__get_bibs_by_upc(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_upc("12345")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractSierraSession__parse_response(self):
-        sierra_adapters.AbstractSierraSession.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractSierraSession()
-        with pytest.raises(NotImplementedError) as exc:
-            session._parse_response("foo")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractService__get_bibs_by_id(self):
-        sierra_adapters.AbstractService.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractService()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_id("foo", "isbn")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-    def test_AbstractService_get_bibs_by_id(self):
-        sierra_adapters.AbstractService.__abstractmethods__ = set()
-        session = sierra_adapters.AbstractService()
-        with pytest.raises(NotImplementedError) as exc:
-            session._get_bibs_by_id("foo", "isbn")
-        assert str(exc.value) == "Subclasses should implement this method."
-
-
 @pytest.mark.livetest
 @pytest.mark.usefixtures("live_creds")
 class TestLiveSierraSession:
@@ -212,30 +140,38 @@ class TestMockSierraSession:
 
 
 @pytest.mark.parametrize("library", ["bpl", "nypl"])
-class TestSierraService:
+class TestSierraBibFetcher:
     @pytest.mark.parametrize("matchpoint", ["bib_id", "upc", "isbn", "oclc_number"])
     def test_get_bibs_by_id(self, library, matchpoint, mock_session):
-        session = sierra_adapters.SierraService(session=mock_session)
+        session = sierra_adapters.SierraBibFetcher(
+            session=mock_session, library=library
+        )
         bibs = session.get_bibs_by_id(value="123456789", key=matchpoint)
-        assert bibs == [{"id": "123456789"}]
+        assert bibs[0]["bib_id"] == "123456789"
 
     def test_get_bibs_by_issn(self, library, mock_session):
-        session = sierra_adapters.SierraService(session=mock_session)
+        session = sierra_adapters.SierraBibFetcher(
+            session=mock_session, library=library
+        )
         with pytest.raises(NotImplementedError) as exc:
             session.get_bibs_by_id(value="123456789", key="issn")
         assert "Search by ISSN not implemented" in str(exc.value)
 
     @pytest.mark.parametrize("matchpoint", ["bib_id", "upc", "isbn", "oclc_number"])
     def test_get_bibs_no_value(self, library, matchpoint, mock_session):
-        session = sierra_adapters.SierraService(session=mock_session)
+        session = sierra_adapters.SierraBibFetcher(
+            session=mock_session, library=library
+        )
         bibs = session.get_bibs_by_id(value=None, key=matchpoint)
         assert bibs == []
 
     def test_get_bibs_by_id_invalid_matchpoint(self, library, mock_session):
-        session = sierra_adapters.SierraService(session=mock_session)
+        session = sierra_adapters.SierraBibFetcher(
+            session=mock_session, library=library
+        )
         with pytest.raises(ValueError) as exc:
             session.get_bibs_by_id(value="123456789", key="bar")
         assert (
             str(exc.value)
-            == "Invalid matchpoint. Available matchpoints are: bib_id, oclc_number, isbn, issn, and upc"
+            == "Invalid matchpoint: 'bar'. Available matchpoints are: ['bib_id', 'isbn', 'issn', 'oclc_number', 'upc']"
         )


### PR DESCRIPTION
Changed abstract base classes to protocols:
 - `AbstractUnitOfWork` is now `UnitOfWorkProtocol`
 - `AbstractRepository` is now `RepositoryProtocol`
 - `AbstractService` is now `SierraBibFetcher`. `SierraBibFetcher` is a `BibFetcher` protocol and `SierraBibFetcher.session` is a `SierraSessionProtocol`