### PR TITLE
Match service

### DIFF
--- a/overload_web/domain/match_service.py
+++ b/overload_web/domain/match_service.py
@@ -1,6 +1,47 @@
-from typing import Any, Dict, List, Protocol, runtime_checkable
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from overload_web.domain import model
 
 
 @runtime_checkable
 class BibFetcher(Protocol):
     def get_bibs_by_id(self, value: str | int, key: str) -> List[Dict[str, Any]]: ...
+
+
+class BibMatchService:
+    def __init__(self, fetcher: BibFetcher, matchpoints: Optional[List[str]] = None):
+        self.fetcher = fetcher
+        self.matchpoints = matchpoints or [
+            "oclc_number",
+            "isbn",
+            "issn",
+            "bib_id",
+            "upc",
+        ]
+
+    def _select_best_match(
+        self, bib_to_match: model.DomainBib, candidates: List[Dict[str, Any]]
+    ) -> Optional[str]:
+        max_matched_points = -1
+        best_match_bib_id = None
+        for bib in candidates:
+            matched_points = 0
+            for attr in self.matchpoints:
+                if getattr(bib_to_match, attr) == bib.get(attr):
+                    matched_points += 1
+
+            if matched_points > max_matched_points:
+                max_matched_points = matched_points
+                best_match_bib_id = bib.get("bib_id")
+
+        return best_match_bib_id
+
+    def find_best_match(self, bib: model.DomainBib) -> Optional[str]:
+        for key in self.matchpoints:
+            value = getattr(bib, key, None)
+            if not value:
+                continue
+            candidates = self.fetcher.get_bibs_by_id(value=value, key=key)
+            if candidates:
+                return self._select_best_match(bib_to_match=bib, candidates=candidates)
+        return None

--- a/overload_web/domain/model.py
+++ b/overload_web/domain/model.py
@@ -21,20 +21,6 @@ class DomainBib:
         for order in self.orders:
             order.apply_template(template_data=template_data)
 
-    def match(self, bibs: List[DomainBib], matchpoints: List[str]) -> None:
-        max_matched_points = -1
-        best_match_bib_id = None
-        for bib in bibs:
-            matched_points = 0
-            for attr in matchpoints:
-                if getattr(self, attr) == getattr(bib, attr):
-                    matched_points += 1
-
-            if matched_points > max_matched_points:
-                max_matched_points = matched_points
-                best_match_bib_id = bib.bib_id
-        self.bib_id = best_match_bib_id
-
     @classmethod
     def from_marc(cls, bib: bookops_marc.Bib) -> DomainBib:
         orders = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,62 +128,63 @@ def make_domain_bib(library, order_data):
 
 
 @pytest.fixture
-def stub_960() -> Field:
-    return Field(
-        tag="960",
-        indicators=Indicators(" ", " "),
-        subfields=[
-            Subfield(code="a", value="l"),
-            Subfield(code="b", value="-"),
-            Subfield(code="c", value="j"),
-            Subfield(code="d", value="c"),
-            Subfield(code="e", value="d"),
-            Subfield(code="f", value="a"),
-            Subfield(code="g", value="b"),
-            Subfield(code="h", value="-"),
-            Subfield(code="i", value="l"),
-            Subfield(code="j", value="-"),
-            Subfield(code="m", value="o"),
-            Subfield(code="n", value="-"),
-            Subfield(code="o", value="13"),
-            Subfield(code="p", value="  -  -  "),
-            Subfield(code="q", value="01-01-25"),
-            Subfield(code="r", value="  -  -  "),
-            Subfield(code="s", value="{{dollar}}13.20"),
-            Subfield(code="t", value="agj0y"),
-            Subfield(code="u", value="lease"),
-            Subfield(code="v", value="btlea"),
-            Subfield(code="w", value="eng"),
-            Subfield(code="x", value="xxu"),
-            Subfield(code="y", value="1"),
-            Subfield(code="z", value=".o10000010"),
-        ],
-    )
-
-
-@pytest.fixture
-def stub_961() -> Field:
-    return Field(
-        tag="961",
-        indicators=Indicators(" ", " "),
-        subfields=[
-            Subfield(code="d", value="foo"),
-            Subfield(code="f", value="bar"),
-            Subfield(code="h", value="baz"),
-            Subfield(code="i", value="foo"),
-            Subfield(code="l", value="bar"),
-            Subfield(code="m", value="baz"),
-        ],
-    )
-
-
-@pytest.fixture
-def stub_bib(library, stub_960, stub_961) -> Bib:
+def stub_bib(library) -> Bib:
     bib = Bib()
     bib.leader = "02866pam  2200517 i 4500"
     bib.library = library
-    bib.add_field(stub_960)
-    bib.add_field(stub_961)
+    bib.add_field(
+        Field(
+            tag="020",
+            indicators=Indicators(" ", " "),
+            subfields=[Subfield(code="a", value="9781234567890")],
+        )
+    )
+    bib.add_field(
+        Field(
+            tag="960",
+            indicators=Indicators(" ", " "),
+            subfields=[
+                Subfield(code="a", value="l"),
+                Subfield(code="b", value="-"),
+                Subfield(code="c", value="j"),
+                Subfield(code="d", value="c"),
+                Subfield(code="e", value="d"),
+                Subfield(code="f", value="a"),
+                Subfield(code="g", value="b"),
+                Subfield(code="h", value="-"),
+                Subfield(code="i", value="l"),
+                Subfield(code="j", value="-"),
+                Subfield(code="m", value="o"),
+                Subfield(code="n", value="-"),
+                Subfield(code="o", value="13"),
+                Subfield(code="p", value="  -  -  "),
+                Subfield(code="q", value="01-01-25"),
+                Subfield(code="r", value="  -  -  "),
+                Subfield(code="s", value="{{dollar}}13.20"),
+                Subfield(code="t", value="agj0y"),
+                Subfield(code="u", value="lease"),
+                Subfield(code="v", value="btlea"),
+                Subfield(code="w", value="eng"),
+                Subfield(code="x", value="xxu"),
+                Subfield(code="y", value="1"),
+                Subfield(code="z", value=".o10000010"),
+            ],
+        )
+    )
+    bib.add_field(
+        Field(
+            tag="961",
+            indicators=Indicators(" ", " "),
+            subfields=[
+                Subfield(code="d", value="foo"),
+                Subfield(code="f", value="bar"),
+                Subfield(code="h", value="baz"),
+                Subfield(code="i", value="foo"),
+                Subfield(code="l", value="bar"),
+                Subfield(code="m", value="baz"),
+            ],
+        )
+    )
     return bib
 
 

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from fastapi.testclient import TestClient
 
@@ -35,7 +33,6 @@ class TestAPIRouter:
     def test_process_vendor_file_post(
         self, stub_pvf_form_data, stub_binary_marc, library, destination
     ):
-        os.environ["library"] = library
         response = self.client.post(
             "/vendor_file",
             files={"file": ("marc_file.mrc", stub_binary_marc, "text/plain")},
@@ -55,7 +52,6 @@ class TestAPIRouter:
     def test_process_vendor_file_post_invalid_config(
         self, stub_binary_marc, stub_pvf_form_data, library, destination
     ):
-        os.environ["library"] = library
         with pytest.raises(ValueError) as exc:
             self.client.post(
                 "/vendor_file",

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -34,35 +34,10 @@ class MockUnitOfWork(unit_of_work.UnitOfWorkProtocol):
 @pytest.mark.usefixtures("mock_sierra_response")
 @pytest.mark.parametrize("library", ["nypl", "bpl"])
 class TestApplicationServices:
-    def test_get_bibs_by_key(self, bib_data, library):
-        bib_data["isbn"] = "9781234567890"
-        bibs = services.get_bibs_by_key(
-            uow=MockUnitOfWork(), bib=bib_data, matchpoints=["isbn"]
-        )
-        assert len(bibs) == 4
-        assert bibs == [
-            {"bib_id": "123", "isbn": "9781234567890"},
-            {"bib_id": "234", "isbn": "1234567890", "oclc_number": "123456789"},
-            {
-                "bib_id": "345",
-                "isbn": "9781234567890",
-                "oclc_number": "123456789",
-            },
-            {"bib_id": "456", "upc": "333"},
-        ]
-
-    def test_get_bibs_by_key_None(self, bib_data, library):
-        bibs = services.get_bibs_by_key(
-            uow=MockUnitOfWork(),
-            bib=bib_data,
-            matchpoints=["isbn"],
-        )
-        assert bibs == []
-
     def test_match_bib(self, bib_data, library):
         bib_data["isbn"] = "9781234567890"
         matched_bib = services.match_bib(
-            uow=MockUnitOfWork(),
+            fetcher=FakeBibFetcher(),
             bib=bib_data,
             matchpoints=["bib_id", "upc", "isbn", "oclc_number"],
         )

--- a/tests/unit/test_sierra_adapters.py
+++ b/tests/unit/test_sierra_adapters.py
@@ -46,7 +46,6 @@ class TestLiveSierraSession:
                 "publishYear",
                 "title",
             ]
-            assert matched_bibs[0]["id"] == "12187266"
 
     def test_NYPLPlatformSession_live(self):
         with sierra_adapters.NYPLPlatformSession() as session:
@@ -80,63 +79,6 @@ class TestLiveSierraSession:
                 "updatedDate",
                 "varFields",
             ]
-            assert matched_bibs[0]["id"] == "21730445"
-            assert matched_bibs[1]["id"] == "21790265"
-
-
-@pytest.mark.usefixtures("mock_sierra_response")
-class TestMockSierraSession:
-    def test_BPLSolrSession__get_bibs_by_bib_id(self):
-        with sierra_adapters.BPLSolrSession() as session:
-            matched_bib = session._get_bibs_by_bib_id("123456789")
-            assert matched_bib.json() == {"response": {"docs": [{"id": "123456789"}]}}
-
-    def test_BPLSolrSession__get_bibs_by_isbn(self):
-        with sierra_adapters.BPLSolrSession() as session:
-            matched_bib = session._get_bibs_by_isbn("123456789")
-            assert matched_bib.json() == {"response": {"docs": [{"id": "123456789"}]}}
-
-    def test_BPLSolrSession__get_bibs_by_issn(self):
-        with sierra_adapters.BPLSolrSession() as session:
-            with pytest.raises(NotImplementedError) as exc:
-                session._get_bibs_by_issn("foo")
-            assert str(exc.value) == "Search by ISSN not implemented in BPL Solr"
-
-    def test_BPLSolrSession__get_bibs_by_oclc_number(self):
-        with sierra_adapters.BPLSolrSession() as session:
-            matched_bib = session._get_bibs_by_oclc_number("123456789")
-            assert matched_bib.json() == {"response": {"docs": [{"id": "123456789"}]}}
-
-    def test_BPLSolrSession__get_bibs_by_upc(self):
-        with sierra_adapters.BPLSolrSession() as session:
-            matched_bib = session._get_bibs_by_upc("123456789")
-            assert matched_bib.json() == {"response": {"docs": [{"id": "123456789"}]}}
-
-    def test_NYPLPlatformSession__get_bibs_by_bib_id(self):
-        with sierra_adapters.NYPLPlatformSession() as session:
-            matched_bib = session._get_bibs_by_bib_id("123456789")
-            assert matched_bib.json() == {"data": [{"id": "123456789"}]}
-
-    def test_NYPLPlatformSession__get_bibs_by_isbn(self):
-        with sierra_adapters.NYPLPlatformSession() as session:
-            matched_bib = session._get_bibs_by_isbn("123456789")
-            assert matched_bib.json() == {"data": [{"id": "123456789"}]}
-
-    def test_NYPLPlatformSession__get_bibs_by_issn(self):
-        with sierra_adapters.NYPLPlatformSession() as session:
-            with pytest.raises(NotImplementedError) as exc:
-                session._get_bibs_by_issn("foo")
-            assert str(exc.value) == "Search by ISSN not implemented in NYPL Platform"
-
-    def test_NYPLPlatformSession__get_bibs_by_oclc_number(self):
-        with sierra_adapters.NYPLPlatformSession() as session:
-            matched_bib = session._get_bibs_by_oclc_number("123456789")
-            assert matched_bib.json() == {"data": [{"id": "123456789"}]}
-
-    def test_NYPLPlatformSession__get_bibs_by_upc(self):
-        with sierra_adapters.NYPLPlatformSession() as session:
-            matched_bib = session._get_bibs_by_upc("123456789")
-            assert matched_bib.json() == {"data": [{"id": "123456789"}]}
 
 
 @pytest.mark.parametrize("library", ["bpl", "nypl"])


### PR DESCRIPTION
Added
 - `BibMatchService` class

Changed
 - simplified `stub_bib` fixture
 - `match_bib` function in application services now uses `BibFetcher` instead of unit of work

Removed
 - `DomainBib.match` method
 - unused envars in `test_api.py`
 - duplicate tests in `test_sierra_adapters.py`
 - `get_bibs_by_key` function in application services. functionality is now in `BibMatchService`