### PR TITLE
Repository and Unit of Work changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def in_memory_db():
 
 
 @pytest.fixture
-def session(in_memory_db):
+def test_sql_session(in_memory_db):
     orm.start_mappers()
     yield sessionmaker(bind=in_memory_db)()
     clear_mappers()

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -5,8 +5,8 @@ from overload_web.domain import model
 from overload_web.infrastructure import repository
 
 
-def test_SqlAlchemyRepository(session):
-    repo = repository.SqlAlchemyRepository(session=session)
+def test_SqlAlchemyRepository(test_sql_session):
+    repo = repository.SqlAlchemyRepository(session=test_sql_session)
     assert hasattr(repo, "session")
 
 
@@ -19,8 +19,8 @@ def test_SqlAlchemyRepository(session):
         (4, "Qux Template", "user3"),
     ],
 )
-def test_SqlAlchemyRepository_get_save(id, name, agent, session):
-    repo = repository.SqlAlchemyRepository(session=session)
+def test_SqlAlchemyRepository_get_save(id, name, agent, test_sql_session):
+    repo = repository.SqlAlchemyRepository(session=test_sql_session)
     template = model.Template(
         id=id,
         name=name,
@@ -34,8 +34,8 @@ def test_SqlAlchemyRepository_get_save(id, name, agent, session):
     assert saved_template == template
 
 
-def test_mappers(session):
-    session.execute(
+def test_mappers(test_sql_session):
+    test_sql_session.execute(
         text(
             "INSERT INTO templates (id, name, agent, vendor_code, primary_matchpoint)"
             "VALUES"
@@ -67,4 +67,4 @@ def test_mappers(session):
             matchpoints=model.Matchpoints(primary="isbn"),
         ),
     ]
-    assert session.query(model.Template).all() == expected
+    assert test_sql_session.query(model.Template).all() == expected

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1,23 +1,8 @@
 import pytest
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import clear_mappers, sessionmaker
+from sqlalchemy import text
 
 from overload_web.domain import model
-from overload_web.infrastructure import orm, repository
-
-
-@pytest.fixture
-def in_memory_db():
-    engine = create_engine("sqlite:///:memory:")
-    orm.metadata.create_all(engine)
-    return engine
-
-
-@pytest.fixture
-def session(in_memory_db):
-    orm.start_mappers()
-    yield sessionmaker(bind=in_memory_db)()
-    clear_mappers()
+from overload_web.infrastructure import repository
 
 
 def test_SqlAlchemyRepository(session):

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -20,9 +20,7 @@ class FakeBibFetcher(match_service.BibFetcher):
 class MockUnitOfWork(unit_of_work.UnitOfWorkProtocol):
     def __init__(self):
         self.session = None
-        self.sierra_session = None
-        self.db_bibs = []
-        self.bibs = FakeBibFetcher()
+        self.templates = []
 
     def commit(self):
         self.committed = True


### PR DESCRIPTION
Changed
 - simplified api calls and returns in classes within `sierra_adapters`
 - moved fixtures from `test_repository` to `conftest` and renamed to clarify purpose of fixtures

Removed
 - Sierra services from unit of work
 - remaining references to abstract base class in unit of work pattern
 - `SierraServiceFactory` as it is no longer needed in unit of work